### PR TITLE
switch jsx mode to react-jsx

### DIFF
--- a/bazel/ts/defs.bzl
+++ b/bazel/ts/defs.bzl
@@ -1,7 +1,7 @@
-load("//bazel/js:js.bzl", "js_binary")
 load("@aspect_rules_swc//swc:defs.bzl", "swc")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@bazel_skylib//lib:partial.bzl", "partial")
+load("//bazel/js:js.bzl", "js_binary")
 
 def ts_binary(name, srcs = [], deps = [], **kwargs):
     if len(srcs) != 1:
@@ -38,6 +38,5 @@ def ts_library(name, srcs = [], deps = [], **kwargs):
             swcrc = "//:.swcrc",
         ),
         tsconfig = "//:tsconfig",
-        preserve_jsx = True,
         **kwargs
     )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "lib": [
       "dom",
       "esnext"


### PR DESCRIPTION
From ChatGPT

"jsx": "react-jsx": This option is used with TypeScript versions 4.1 and later, designed for the new JSX runtime introduced in React 17. It compiles JSX directly to React.createElement or jsx/jsxs from react/jsx-runtime without the need to import React manually.

"jsx": "preserve": This option keeps the JSX syntax in the output, which is useful when you want a separate tool (like Babel or Webpack) to handle the transformation from JSX to JavaScript. The TypeScript compiler does not change JSX code, leaving it as is.