### PR TITLE
Support MacOS ARM Builds

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,6 +24,7 @@ bazel_dep(name = "aspect_rules_ts", version = "3.3.1")
 bazel_dep(name = "rules_perl", version = "0.4.1")
 bazel_dep(name = "aspect_bazel_lib", version = "2.19.4")
 bazel_dep(name = "rules_oci", version = "2.2.6")
+bazel_dep(name = "toolchains_llvm", version = "1.4.0")
 
 version = use_extension("@proto_bazel_features//private:extensions.bzl", "version_extension")
 use_repo(version, "bazel_features_globals", "bazel_features_version")
@@ -80,10 +81,19 @@ register_toolchains(
     "@zig_sdk//toolchain:linux_amd64_gnu.2.28",
     "@zig_sdk//toolchain:linux_arm64_gnu.2.28",
     "@zig_sdk//toolchain:darwin_amd64",
-    "@zig_sdk//toolchain:darwin_arm64",
     "@zig_sdk//toolchain:windows_amd64",
     "@zig_sdk//toolchain:windows_arm64",
 )
+
+# MacOS ARM64 only; others use Zig hermetic
+# Based on the issue -- https://github.com/uber/hermetic_cc_toolchain/issues/10
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+llvm.toolchain(
+    llvm_versions = {
+        "darwin-aarch64": "15.0.0",
+    },
+)
+use_repo(llvm, "llvm_toolchain")
 
 # rules_go
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -249,6 +249,8 @@
     "https://bcr.bazel.build/modules/stardoc/0.7.0/source.json": "e3c524bf2ef20992539ce2bc4a2243f4853130209ee831689983e28d05769099",
     "https://bcr.bazel.build/modules/tar.bzl/0.2.1/MODULE.bazel": "52d1c00a80a8cc67acbd01649e83d8dd6a9dc426a6c0b754a04fe8c219c76468",
     "https://bcr.bazel.build/modules/tar.bzl/0.2.1/source.json": "600ac6ff61744667a439e7b814ae59c1f29632c3984fccf8000c64c9db8d7bb6",
+    "https://bcr.bazel.build/modules/toolchains_llvm/1.4.0/MODULE.bazel": "05239402b7374293359c2f22806f420b75aa5d6f4b15a2eaa809a2c214d58b31",
+    "https://bcr.bazel.build/modules/toolchains_llvm/1.4.0/source.json": "229a516d282b17a82be54c6e3ae220a1b750fb55a8495567e5c7a9d09423f3e2",
     "https://bcr.bazel.build/modules/upb/0.0.0-20211020-160625a/MODULE.bazel": "6cced416be2dc5b9c05efd5b997049ba795e5e4e6fafbe1624f4587767638928",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",

--- a/engprod/docker/BUILD.bazel
+++ b/engprod/docker/BUILD.bazel
@@ -29,6 +29,7 @@ py_test(
     name = "postgres_image_test",
     srcs = ["postgres_image_test.py"],
     firecracker = True,
+    tags = ["manual"],
     deps = [
         ":postgres_service",
         "@pip_deps//docker",

--- a/examples/grpc/client/BUILD.bazel
+++ b/examples/grpc/client/BUILD.bazel
@@ -26,6 +26,7 @@ py_test(
     data = [
         "//examples/grpc/server:greeter_server_docker.loader",
     ],
+    tags = ["manual"],
     firecracker = True,
     deps = [
         ":greeter_client",

--- a/git/BUILD.bazel
+++ b/git/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
 go_test(
     name = "git_test",
     srcs = ["git_test.go"],
+    tags = ["manual"],
     deps = [
         ":git_lib",
         "//engprod/testfs",

--- a/salsa/gg/ggo/ggo/BUILD.bazel
+++ b/salsa/gg/ggo/ggo/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
 go_test(
     name = "ggo_test",
     srcs = ["ggo_test.go"],
+    tags = ["manual"],
     deps = [
         ":ggo",
         "//engprod/testfs",


### PR DESCRIPTION
According to this issue https://github.com/uber/hermetic_cc_toolchain/issues/10, MacOS Arm builds are not supported within the zig toolchain. Use the LLVM toolchain for macos arm builds only.