### PR TITLE
Remove Recycled Runners from Exec Properties

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,8 @@ build:remote --platforms=//:docker_image_platform
 build:remote --remote_timeout=1800
 build:remote --jobs=50
 
+build:ci --config=remote
+build:ci --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
 
 test --test_output=errors
 

--- a/bazel/python.bzl
+++ b/bazel/python.bzl
@@ -9,6 +9,7 @@ FIRECRACKER_EXEC_PROPERTIES = {
     "test.init-dockerd": "true",
     # Tell BuildBuddy to preserve the microVM state across test runs.
     "test.recycle-runner": "true",
+    "include-secrets": "true",
     "container-image": "docker://docker.io/juanzolotoochin/ubuntu-build-v2@sha256:4a898ae754ac575962392232dc0154937427bbd52f5b79cd65c0992b2ed6cc84",
 }
 

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -9,4 +9,4 @@ actions:
         branches:
           - "master"
     bazel_commands:
-      - "test --config=remote //..."
+      - "test --config=ci //..."


### PR DESCRIPTION
Because we are getting the following error from CI : 
```
Invalid Argument: error creating runner for command: runner recycling is not supported for anonymous builds (recycling was requested via platform property "recycle-runner=true")
```